### PR TITLE
switching close, open and chain transactions to use grammy from request

### DIFF
--- a/post/post_chain_transaction.js
+++ b/post/post_chain_transaction.js
@@ -44,7 +44,7 @@ module.exports = ({confirmed, from, id, key, send, transaction}, cbk) => {
         }
 
         if (!send) {
-          return cbk([400, 'ExpectedSendToPostChainTransaction']);
+          return cbk([400, 'ExpectedSendFunctionToPostChainTransaction']);
         }
 
         if (!transaction) {

--- a/post/post_chain_transaction.js
+++ b/post/post_chain_transaction.js
@@ -139,7 +139,7 @@ module.exports = ({confirmed, from, id, key, send, transaction}, cbk) => {
   
             return cbk();
           } catch (err) {
-            return cbk([503, 'UnexpectedErrorPostingChannelOpenMessage', {err}]);
+            return cbk([503, 'UnexpectedErrorPostingChainTransaction', {err}]);
           }
         })();
       }],

--- a/post/post_chain_transaction.js
+++ b/post/post_chain_transaction.js
@@ -30,7 +30,7 @@ const tokAsBig = tokens => (tokens / 1e8).toFixed(8);
 
   @returns via cbk or Promise
 */
-module.exports = ({confirmed, from, id, key, request, transaction}, cbk) => {
+module.exports = ({confirmed, from, id, key, send, transaction}, cbk) => {
   return new Promise((resolve, reject) => {
     return asyncAuto({
       // Check arguments
@@ -43,12 +43,8 @@ module.exports = ({confirmed, from, id, key, request, transaction}, cbk) => {
           return cbk([400, 'ExpectedConnectedUserIdToPostChainTransaction']);
         }
 
-        if (!key) {
-          return cbk([400, 'ExpectedApiKeyToPostChainTransaction']);
-        }
-
-        if (!request) {
-          return cbk([400, 'ExpectedRequestToPostChainTransaction']);
+        if (!send) {
+          return cbk([400, 'ExpectedSendToPostChainTransaction']);
         }
 
         if (!transaction) {
@@ -137,8 +133,15 @@ module.exports = ({confirmed, from, id, key, request, transaction}, cbk) => {
         const pending = !confirmed ? '(pending)' : '';
 
         const text = `${emoji} ${pending} ${details}\n${from}`;
-
-        return sendMessage({id, key, request, text}, cbk);
+        return (async () => {
+          try {
+            await send(id, text);
+  
+            return cbk();
+          } catch (err) {
+            return cbk([503, 'UnexpectedErrorPostingChannelOpenMessage', {err}]);
+          }
+        })();
       }],
     },
     returnResult({reject, resolve}, cbk));

--- a/post/post_closed_message.js
+++ b/post/post_closed_message.js
@@ -62,10 +62,6 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedRemoteForceCloseToPostCloseMessage']);
         }
 
-        if (!args.key) {
-          return cbk([400, 'ExpectedTelegramApiKeyToPostCloseMessage']);
-        }
-
         if (!args.lnd) {
           return cbk([400, 'ExpectedAuthenticatedLndToPostCloseMessage']);
         }
@@ -74,8 +70,8 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedPartnerPublicKeyToPostCloseMessage']);
         }
 
-        if (!args.request) {
-          return cbk([400, 'ExpectedRequestFunctionToPostCloseMessage']);
+        if (!args.send) {
+          return cbk([400, 'ExpectedSendFunctionToPostCloseMessage']);
         }
 
         return cbk();
@@ -122,13 +118,15 @@ module.exports = (args, cbk) => {
 
       // Send channel open message
       send: ['message', ({message}, cbk) => {
-        return sendMessage({
-          id: args.id,
-          key: args.key,
-          request: args.request,
-          text: message.text,
-        },
-        cbk);
+        return (async () => {
+        try {
+          await args.send(args.id, message.text);
+
+          return cbk();
+        } catch (err) {
+          return cbk([503, 'UnexpectedErrorPostingChannelClosedMessage', {err}]);
+        }
+      })();
       }],
     },
     returnResult({reject, resolve, of: 'message'}, cbk));

--- a/post/post_open_message.js
+++ b/post/post_open_message.js
@@ -48,10 +48,6 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedPrivateStatusToPostChannelOpenMessage']);
         }
 
-        if (!args.key) {
-          return cbk([400, 'ExpectedTelegramApiKeyToPostChannelOpenMessage']);
-        }
-
         if (!args.lnd) {
           return cbk([400, 'ExpectedLndToPostChannelOpenMessage']);
         }
@@ -60,8 +56,8 @@ module.exports = (args, cbk) => {
           return cbk([400, 'ExpectedPartnerPublicKeyToPostChanOpenMessage']);
         }
 
-        if (!args.request) {
-          return cbk([400, 'ExpectedRequestFunctionToPostChanOpenMessage']);
+        if (!args.send) {
+          return cbk([400, 'ExpectedSendFunctionToPostChanOpenMessage']);
         }
 
         return cbk();
@@ -99,13 +95,15 @@ module.exports = (args, cbk) => {
 
       // Send channel open message
       send: ['message', ({message}, cbk) => {
-        return sendMessage({
-          id: args.id,
-          key: args.key,
-          request: args.request,
-          text: message.text,
-        },
-        cbk);
+        return (async () => {
+          try {
+            await args.send(args.id, message.text);
+  
+            return cbk();
+          } catch (err) {
+            return cbk([503, 'UnexpectedErrorPostingChannelOpenMessage', {err}]);
+          }
+        })();
       }],
     },
     returnResult({reject, resolve, of: 'message'}, cbk));


### PR DESCRIPTION
Switching 3 commands to use grammy.

postOpenMessage
postClosedMessage
postChainTransaction

Files changed:

- post/post_chain_transaction.js
- post/post_closed_message.js
- post/post_open_message.js