### PR TITLE
show millisats in the forwarded message if "full tokens type" is set

### DIFF
--- a/post/consolidate_forwards.js
+++ b/post/consolidate_forwards.js
@@ -28,10 +28,10 @@ module.exports = ({forwards}) => {
 
     sum[pair] = sum[pair] || {};
 
-    sum[pair].fee = (sum[pair].fee || Number()) + forward.fee;
+    sum[pair].fee = (sum[pair].fee || Number()) + Number(forward.fee_mtokens) / 1e3;
     sum[pair].incoming_channel = forward.incoming_channel;
     sum[pair].outgoing_channel = forward.outgoing_channel;
-    sum[pair].tokens = (sum[pair].tokens || Number()) + forward.tokens;
+    sum[pair].tokens = (sum[pair].tokens || Number()) + Number(forward.mtokens) / 1e3;
 
     return sum;
   },


### PR DESCRIPTION
Related to alexbosworth/balanceofsatoshis#219

To do that the only thing that I've do was adding the millisats to the tokens/fee values, in this way even the ppm fee rate and percent is more accurate also for users that don't use the "full tokens type"