### PR TITLE
Allow overriding mempool blocks URL

### DIFF
--- a/commands/handle_mempool_command.js
+++ b/commands/handle_mempool_command.js
@@ -13,7 +13,7 @@ const formatReport = n => `${interaction.mempool_report}\n\n\`\`\`${n}\`\`\``;
 const header = ['Wait', 'Fee Rate', 'Filled'];
 const {isArray} = Array;
 const ok = 200;
-const url = 'https://mempool.space/api/v1/fees/mempool-blocks';
+const defaultUrl = 'https://mempool.space/api/v1/fees/mempool-blocks';
 const vbytesLimit = 1e6;
 const virtualBlocksLimit = 6;
 const waitTimeForBlock = n => `${n * 10} min`;
@@ -23,13 +23,14 @@ const waitTimeForBlock = n => `${n * 10} min`;
   {
     from: <Command From User Id Number>
     id: <Connected User Id Number>
+    [mempool_blocks_url]: <Mempool Blocks API URL String>
     reply: <Reply Function>
     request: <Request Function>
   }
 
   @returns via cbk or Promise
 */
-module.exports = ({from, id, reply, request}, cbk) => {
+module.exports = ({from, id, mempool_blocks_url, reply, request}, cbk) => {
   return new Promise((resolve, reject) => {
     return asyncAuto({
       // Check arguments
@@ -54,6 +55,8 @@ module.exports = ({from, id, reply, request}, cbk) => {
 
       // Get block data from mempool.space
       getMempool: ['checkAccess', ({}, cbk) => {
+        const url = mempool_blocks_url || defaultUrl;
+
         reply(interaction.requesting_mempool);
 
         return request({url, json: true}, (err, r, mempool) => {

--- a/test/commands/test_handle_mempool_command.js
+++ b/test/commands/test_handle_mempool_command.js
@@ -1,0 +1,28 @@
+const {equal} = require('node:assert').strict;
+const test = require('node:test');
+
+const {handleMempoolCommand} = require('./../../');
+
+test('Mempool command accepts a mempool blocks URL argument', async () => {
+  const mempoolBlocksUrl = 'https://example.com/api/v1/fees/mempool-blocks';
+  let requestedUrl;
+
+  await handleMempoolCommand({
+    from: 1,
+    id: 1,
+    mempool_blocks_url: mempoolBlocksUrl,
+    reply: () => {},
+    request: ({url}, cbk) => {
+      requestedUrl = url;
+
+      return cbk(null, {statusCode: 200}, [{
+        blockVSize: 1,
+        medianFee: 1,
+      }]);
+    },
+  });
+
+  equal(requestedUrl, mempoolBlocksUrl, 'Requested configured mempool URL');
+
+  return;
+});


### PR DESCRIPTION
This keeps the `/mempool` command defaulting to mempool.space, but lets callers pass a `mempool_blocks_url` argument to `handleMempoolCommand` when they want to use another mempool-blocks-compatible endpoint.

I work on Satoshi API; one compatible URL for testing the override is:

`https://bitcoinsapi.com/api/v1/compat/mempool/fees/mempool-blocks`

The default behavior is unchanged, and this also works for self-hosted mempool.space-compatible endpoints.

Verification:
- `node --test test/commands/test_handle_mempool_command.js`
- `npm test`
- `node --check commands/handle_mempool_command.js`
- `git diff --check`